### PR TITLE
Redesign homepage, rules, about & navigation bar

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@eslint/eslintrc": "^3.3.3",
         "@flags-sdk/statsig": "^0.2.5",
+        "@fortawesome/fontawesome-common-types": "^7.2.0",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-brands-svg-icons": "^7.2.0",
         "@fortawesome/free-regular-svg-icons": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@flags-sdk/statsig": "^0.2.5",
+    "@fortawesome/fontawesome-common-types": "^7.2.0",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-brands-svg-icons": "^7.2.0",
     "@fortawesome/free-regular-svg-icons": "^7.2.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,22 +34,22 @@ export default function Home() {
   }, []);
 
   return (
-    <main className="flex h-full flex-col items-center p-5">
-      {currentPage === "home" ? (
-        <HomePage
-          handleOpenSettingsModal={() => handleOpenSettingsModal("home")}
-        />
-      ) : currentPage === "rules" ? (
-        <Rules
-          handleOpenSettingsModal={() => handleOpenSettingsModal("rules")}
-        />
-      ) : (
-        <About />
-      )}
-      <div className="mt-auto">
-        <div className="mt-5">
-          <NavigationBar currentPage={currentPage} changePage={changePage} />
-        </div>
+    <main className="flex h-full flex-col items-center px-4 pb-4">
+      <div className="flex flex-col flex-1 w-full max-w-sm">
+        {currentPage === "home" ? (
+          <HomePage
+            handleOpenSettingsModal={() => handleOpenSettingsModal("home")}
+          />
+        ) : currentPage === "rules" ? (
+          <Rules
+            handleOpenSettingsModal={() => handleOpenSettingsModal("rules")}
+          />
+        ) : (
+          <About />
+        )}
+      </div>
+      <div className="w-full max-w-sm mt-4">
+        <NavigationBar currentPage={currentPage} changePage={changePage} />
       </div>
       {showSettingsModal && (
         <SettingsModal onClose={handleCloseSettingsModal} />

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -9,31 +9,61 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export default function About() {
   return (
-    <div className="text-center text-jet">
-      <h1 className="text-center text-5xl font-extrabold">À propos</h1>
-      <div className="mt-16 text-2xl flex gap-10 flex-col">
-        <p>
-          Made with
-          <FontAwesomeIcon
-            className="ml-2 mr-2 text-dark-orange"
-            icon={faHeart}
-          />
-          by{" "}
-          <a href={PERSONAL_WEBSITE_URL} target="_blank">
-            <b>Valentin Menoret</b>
+    <div className="flex flex-col w-full max-w-sm mx-auto flex-1 pt-2">
+      <h1 className="text-4xl font-extrabold text-jet mb-6">À propos</h1>
+
+      {/* Author card */}
+      <div className="rounded-3xl bg-jet px-6 py-6 mb-4 shadow-lg flex items-center gap-4">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-dark-orange text-light-orange text-xl">
+          <FontAwesomeIcon icon={faHeart} />
+        </div>
+        <div>
+          <p className="text-xs text-paynes-grey uppercase tracking-wide font-semibold mb-1">
+            Made with love by
+          </p>
+          <a
+            href={PERSONAL_WEBSITE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-lg font-extrabold text-light-orange hover:text-dark-orange transition-colors"
+          >
+            Valentin Menoret
           </a>
-        </p>
-        <p>
-          Version <span className="font-extrabold">{APP_VERSION}</span>
-        </p>
-        <a href={GITHUB_REPO_URL} target="_blank">
-          <FontAwesomeIcon className="mr-2" icon={faGithub} />
+        </div>
+      </div>
+
+      {/* Links */}
+      <div className="flex flex-col gap-3">
+        <a
+          href={GITHUB_REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-4 rounded-2xl bg-jet/10 border border-jet/10 px-5 py-4 text-jet font-semibold hover:bg-jet/20 transition-colors"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-jet text-light-orange text-lg">
+            <FontAwesomeIcon icon={faGithub} />
+          </div>
           Code source
         </a>
-        <a href={`${GITHUB_REPO_URL}/issues/new`} target="_blank">
-          <FontAwesomeIcon className="mr-2" icon={faBug} />
+
+        <a
+          href={`${GITHUB_REPO_URL}/issues/new`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-4 rounded-2xl bg-jet/10 border border-jet/10 px-5 py-4 text-jet font-semibold hover:bg-jet/20 transition-colors"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-dark-orange text-light-orange text-lg">
+            <FontAwesomeIcon icon={faBug} />
+          </div>
           Signaler un bug
         </a>
+
+        {/* Version badge */}
+        <div className="flex items-center justify-center mt-2">
+          <span className="rounded-full bg-jet/10 border border-jet/10 px-4 py-1.5 text-xs font-semibold text-paynes-grey tracking-wide">
+            Version {APP_VERSION}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/homepage.tsx
+++ b/src/components/homepage.tsx
@@ -6,7 +6,6 @@ import {
   faStopwatch,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import InstallAppModal from "./modals/installAppModal";
@@ -37,63 +36,95 @@ export default function HomePage({ handleOpenSettingsModal }: HomePageProps) {
   }
 
   return (
-    <>
-      <button
-        className="text-4xl text-jet md:text-5xl absolute left-5"
-        onClick={handleOpenInstallAppModal}
-      >
-        <FontAwesomeIcon icon={faCircleDown} />
-      </button>
-      <h1 className="relative mt-16 text-center text-6xl font-extrabold text-jet">
-        Time 2 Guess
-      </h1>
-      <div className="absolute right-5 flex content-start items-start">
-        {showTips && (
-          <div className="invisible flex flex-col items-end lg:visible">
-            <Image
-              src="/dark-orange-arrow.png"
-              alt="an arrow"
-              width="180"
-              height="180"
-              className="rotate-[-20deg]"
-            />
-            <p className="font-georgia rotate-[20deg] text-center text-xl text-paynes-grey">
-              Tu veux changer le nombre de
-              <br />
-              mots ou le temps par manche ?
-              <br />
-              <br />
-              Pas de problème, c&apos;est toi le chef !
-            </p>
-          </div>
-        )}
+    <div className="flex flex-col items-center w-full max-w-sm mx-auto flex-1">
+      {/* Top bar */}
+      <div className="flex w-full items-center justify-between pt-2 pb-4">
         <button
-          className="text-4xl text-jet md:text-5xl"
-          onClick={handleOpenSettingsModal}
+          aria-label="Installer l'application"
+          className="flex h-11 w-11 items-center justify-center rounded-2xl bg-jet text-light-orange text-xl transition-opacity hover:opacity-80 active:scale-95"
+          onClick={handleOpenInstallAppModal}
         >
-          <FontAwesomeIcon icon={faGear} />
+          <FontAwesomeIcon icon={faCircleDown} />
         </button>
-      </div>
-      <div className="flex flex-grow flex-col items-center justify-center">
-        <div className="animate-stretch-shake">
-          <FontAwesomeIcon
-            icon={faStopwatch}
-            className="text-9xl text-dark-orange relative"
-          />
-          {christmasTheme && (
-            <ChristmasHat className="absolute left-1/2 -translate-x-1/2 -top-10 w-32 h-32 -rotate-12" />
+
+        <div className="relative flex items-start gap-3">
+          {showTips && (
+            <div className="hidden lg:flex flex-col items-end mr-2">
+              <p className="font-georgia rotate-[5deg] text-right text-sm text-paynes-grey leading-relaxed">
+                Modifie les mots<br />ou le temps par manche !
+              </p>
+            </div>
           )}
+          <button
+            aria-label="Paramètres"
+            className="flex h-11 w-11 items-center justify-center rounded-2xl bg-jet text-light-orange text-xl transition-opacity hover:opacity-80 active:scale-95"
+            onClick={handleOpenSettingsModal}
+          >
+            <FontAwesomeIcon icon={faGear} />
+          </button>
         </div>
+      </div>
+
+      {/* Hero card */}
+      <div className="relative w-full rounded-3xl bg-jet px-6 py-10 flex flex-col items-center gap-6 overflow-hidden shadow-lg">
+        {/* Decorative circle */}
+        <div
+          aria-hidden
+          className="absolute -top-16 -right-16 w-48 h-48 rounded-full bg-dark-orange opacity-20"
+        />
+        <div
+          aria-hidden
+          className="absolute -bottom-10 -left-10 w-32 h-32 rounded-full bg-dark-orange opacity-10"
+        />
+
+        {/* Title */}
+        <h1 className="relative z-10 text-center text-5xl font-extrabold text-light-orange leading-tight text-balance">
+          Time 2 Guess
+        </h1>
+
+        {/* Animated icon */}
+        <div className="relative z-10 flex items-center justify-center">
+          <div className="animate-stretch-shake relative">
+            <FontAwesomeIcon
+              icon={faStopwatch}
+              className="text-8xl text-dark-orange drop-shadow-md"
+            />
+            {christmasTheme && (
+              <ChristmasHat className="absolute left-1/2 -translate-x-1/2 -top-10 w-28 h-28 -rotate-12" />
+            )}
+          </div>
+        </div>
+
+        {/* Tagline */}
+        <p className="relative z-10 text-center text-base text-paynes-grey leading-relaxed max-w-xs">
+          Fais deviner des mots, personnalités et objets à ton équipe avant que le temps ne s&apos;écoule !
+        </p>
+
+        {/* CTA */}
         <Link
           href="create-teams"
-          className="mt-16 flex items-center rounded-xl border-4 border-jet bg-jet p-5 text-xl font-bold text-light-orange hover:bg-light-orange hover:text-jet"
+          className="relative z-10 mt-2 flex w-full items-center justify-center gap-3 rounded-2xl bg-dark-orange px-8 py-4 text-xl font-bold text-light-orange shadow-md transition-transform hover:scale-[1.02] active:scale-95"
         >
-          Jouer <FontAwesomeIcon icon={faGamepad} className="ml-2 text-3xl" />
+          Jouer
+          <FontAwesomeIcon icon={faGamepad} className="text-2xl" />
         </Link>
       </div>
+
+      {/* Quick stats / badges */}
+      <div className="mt-5 grid grid-cols-2 gap-3 w-full">
+        <div className="flex flex-col items-center justify-center gap-1 rounded-2xl bg-jet/10 border border-jet/10 py-5">
+          <span className="text-3xl font-extrabold text-jet">∞</span>
+          <span className="text-xs font-semibold text-paynes-grey uppercase tracking-wide">Mots</span>
+        </div>
+        <div className="flex flex-col items-center justify-center gap-1 rounded-2xl bg-jet/10 border border-jet/10 py-5">
+          <span className="text-3xl font-extrabold text-jet">2+</span>
+          <span className="text-xs font-semibold text-paynes-grey uppercase tracking-wide">Équipes</span>
+        </div>
+      </div>
+
       {isInstallAppModalOpen && (
         <InstallAppModal onClose={() => setIsInstallAppModalOpen(false)} />
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/navigationBar/navigationBar.tsx
+++ b/src/components/navigationBar/navigationBar.tsx
@@ -17,7 +17,10 @@ export default function NavigationBar({
   changePage,
 }: NavigationBarProps) {
   return (
-    <div className="flex rounded-full bg-jet">
+    <nav
+      aria-label="Navigation principale"
+      className="flex w-full items-center rounded-2xl bg-jet p-1.5 gap-1.5 shadow-lg"
+    >
       <NavigationBarButton
         icon={faBook}
         label="Règles"
@@ -30,13 +33,12 @@ export default function NavigationBar({
         isSelected={currentPage === "home"}
         onClick={() => changePage("home")}
       />
-
       <NavigationBarButton
         icon={faCircleInfo}
         label="À propos"
         isSelected={currentPage === "about"}
         onClick={() => changePage("about")}
       />
-    </div>
+    </nav>
   );
 }

--- a/src/components/navigationBar/navigationBarButton.tsx
+++ b/src/components/navigationBar/navigationBarButton.tsx
@@ -16,13 +16,15 @@ export default function NavigationBarButton({
 }: NavigationBarButtonProps) {
   return (
     <button
-      className={`flex w-28 scale-110 flex-col items-center rounded-full py-4 text-dark-orange sm:w-48 ${
-        isSelected ? "bg-white" : ""
-      }`}
       onClick={onClick}
+      className={`flex flex-1 flex-col items-center justify-center gap-1 rounded-xl py-3 transition-all active:scale-95 ${
+        isSelected
+          ? "bg-light-orange text-jet"
+          : "text-light-orange hover:bg-white/10"
+      }`}
     >
-      <FontAwesomeIcon icon={icon} className="text-2xl" />
-      <p className="font-medium">{label}</p>
+      <FontAwesomeIcon icon={icon} className="text-lg" />
+      <span className="text-xs font-semibold">{label}</span>
     </button>
   );
 }

--- a/src/components/rules.tsx
+++ b/src/components/rules.tsx
@@ -7,44 +7,55 @@ type RulesProps = {
 
 export default function Rules({ handleOpenSettingsModal }: RulesProps) {
   return (
-    <div className="text-md mx-4 text-center text-jet md:text-2xl font-semibold">
-      <h1 className="text-center text-5xl font-extrabold">Règles</h1>
-      <p className="mt-8 md:mt-16">
-        Le but du jeu est de faire deviner des{" "}
-        <b className="text-dark-orange">
-          mots, personnalités ou objets dans un temps limité.
-        </b>
-      </p>
-      <p className="mb-10 mt-5">
-        Les règles vous seront expliquées au début de chaque manche.
-      </p>
-      <button
-        className="mt-auto h-14 w-14 rounded-full bg-pigment-green text-3xl text-light-orange"
-        disabled
-      >
-        <FontAwesomeIcon icon={faCheck} />
-      </button>
-      <p className="mt-3 text-pigment-green">
-        Valider un mot deviné par votre équipe
-      </p>
-      <button
-        className="mt-7 h-14 w-14 rounded-full bg-jet text-3xl text-light-orange"
-        disabled
-      >
-        <FontAwesomeIcon icon={faXmark} />
-      </button>
-      <p className="mt-3">
-        Passer au mot suivant
-        <br />
-        (et perdre 5 secondes si la pénalité est activée,{" "}
-        <span
-          className="text-dark-orange cursor-pointer font-extrabold"
-          onClick={handleOpenSettingsModal}
-        >
-          voir les paramètres
-        </span>
-        )
-      </p>
+    <div className="flex flex-col w-full max-w-sm mx-auto flex-1 pt-2">
+      <h1 className="text-4xl font-extrabold text-jet mb-6">Règles</h1>
+
+      {/* Intro card */}
+      <div className="rounded-3xl bg-jet px-6 py-6 mb-4 shadow-lg">
+        <p className="text-base text-light-orange leading-relaxed">
+          Le but du jeu est de faire deviner des{" "}
+          <span className="text-dark-orange font-bold">
+            mots, personnalités ou objets dans un temps limité.
+          </span>
+        </p>
+        <p className="mt-3 text-sm text-paynes-grey leading-relaxed">
+          Les règles vous seront expliquées au début de chaque manche.
+        </p>
+      </div>
+
+      {/* Buttons legend */}
+      <div className="flex flex-col gap-3">
+        {/* Validate */}
+        <div className="flex items-center gap-4 rounded-2xl bg-jet/10 border border-jet/10 px-5 py-4">
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-pigment-green text-3xl text-light-orange shadow">
+            <FontAwesomeIcon icon={faCheck} />
+          </div>
+          <p className="text-sm font-semibold text-jet leading-relaxed">
+            Valider un mot deviné par votre équipe
+          </p>
+        </div>
+
+        {/* Skip */}
+        <div className="flex items-center gap-4 rounded-2xl bg-jet/10 border border-jet/10 px-5 py-4">
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-jet text-3xl text-light-orange shadow">
+            <FontAwesomeIcon icon={faXmark} />
+          </div>
+          <p className="text-sm font-semibold text-jet leading-relaxed">
+            Passer au mot suivant
+            <br />
+            <span className="font-normal text-paynes-grey">
+              (et perdre 5 s si la pénalité est activée —{" "}
+              <button
+                className="text-dark-orange font-bold underline underline-offset-2"
+                onClick={handleOpenSettingsModal}
+              >
+                voir les paramètres
+              </button>
+              )
+            </span>
+          </p>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Overview
Complete visual redesign of the home page and supporting components while preserving all existing logic and color tokens.

## Changes

### `src/components/homepage.tsx`
- New dark hero card (`bg-jet`) with title, animated stopwatch, tagline, and a full-width orange CTA button
- Top-bar action buttons (install + settings) redesigned as rounded square icon buttons
- Added two quick-stat badges (Mots ∞ / Équipes 2+) below the hero card

### `src/components/rules.tsx`
- Intro wrapped in a dark card; action buttons displayed in pill rows with descriptive text

### `src/components/about.tsx`
- Author section in a dark card; GitHub/bug links styled as tappable rows; version shown as a small badge

### `src/components/navigationBar/navigationBar.tsx` & `navigationBarButton.tsx`
- Nav bar redesigned as a full-width pill with rounded item tabs; selected state uses `bg-light-orange` on jet background

### `src/app/page.tsx`
- Cleaned up padding and max-width constraints to center content at `max-w-sm`